### PR TITLE
Add Gaussian mixture data generator and MLP training option

### DIFF
--- a/lj_reflow_template/generate_gaussian_mixture.py
+++ b/lj_reflow_template/generate_gaussian_mixture.py
@@ -1,0 +1,49 @@
+import argparse
+import math
+import h5py
+import torch
+
+def default_means(n_peaks: int, boxlength: float) -> torch.Tensor:
+    if n_peaks == 4:
+        # corners of the box
+        coords = torch.tensor([
+            [0.25, 0.25],
+            [0.75, 0.25],
+            [0.25, 0.75],
+            [0.75, 0.75],
+        ]) * boxlength
+    else:
+        angles = torch.linspace(0, 2 * math.pi, n_peaks, endpoint=False)
+        center = boxlength / 2
+        radius = boxlength / 4
+        coords = torch.stack([
+            center + radius * torch.cos(angles),
+            center + radius * torch.sin(angles),
+        ], dim=1)
+    return coords
+
+def sample_mixture(n_samples: int, npoints: int, boxlength: float, n_peaks: int, sigma: float) -> torch.Tensor:
+    means = default_means(n_peaks, boxlength)
+    peak_idx = torch.randint(0, n_peaks, (n_samples, npoints))
+    selected_means = means[peak_idx]
+    samples = torch.randn(n_samples, npoints, 2) * sigma + selected_means
+    samples = samples % boxlength
+    return samples
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate 2D Gaussian mixture samples")
+    parser.add_argument("out", type=str, help="Output HDF5 file path")
+    parser.add_argument("--n_samples", type=int, default=10000, help="Number of samples to generate")
+    parser.add_argument("--npoints", type=int, default=16, help="Number of points per sample")
+    parser.add_argument("--boxlength", type=float, default=1.0, help="Box length for PBC")
+    parser.add_argument("--n_peaks", type=int, default=4, help="Number of Gaussian peaks")
+    parser.add_argument("--sigma", type=float, default=0.05, help="Standard deviation of Gaussians")
+    args = parser.parse_args()
+
+    data = sample_mixture(args.n_samples, args.npoints, args.boxlength, args.n_peaks, args.sigma)
+    with h5py.File(args.out, "w") as f:
+        f.create_dataset("trajectory", data=data.numpy())
+        f.create_dataset("x0", data=data.numpy())
+
+if __name__ == "__main__":
+    main()

--- a/lj_reflow_template/train.py
+++ b/lj_reflow_template/train.py
@@ -6,6 +6,7 @@ from einops import rearrange, repeat, reduce
 
 from flashdiv.flows.egnn_cutoff import EGNN_dynamics, EGNN_dynamicsPeriodic
 from flashdiv.flows.egnn_periodic import EGNN_dynamicsPeriodic as EGNN_dynamicsPeriodic_noe
+from flashdiv.flows.mlp import MLP
 
 from flashdiv.flows.flow_net_torchdiffeq import FlowNet
 # from flashdiv.flows.message_passing import
@@ -128,6 +129,9 @@ def train_model():
         max_neighbors=max_neighbors,
         distribution=ljsystem
         ).to(device)
+    elif args.nn == 'mlp':
+        input_dim = ljsystem.nparticles * ljsystem.dim
+        velocitynet = MLP(dim=input_dim, hidden_dim=hidden_nf, num_layers=nlayers).to(device)
     velocitytrainer = FlowTrainerTorus(velocitynet, learning_rate=lr, sigma=0.001, boxlength=ljsystem.boxlength)
     ckpt_cb = ModelCheckpoint(
     dirpath=f"flow_model_{args_as_str}/checkpoints",
@@ -174,7 +178,7 @@ parser.add_argument('--learning_rate', type=float, default=0.0005, help='Learnin
 parser.add_argument('--batch_size', type=int, default=256, help='Batch size')
 parser.add_argument('--nb_epochs', type=int, default=30, help='Number of epochs')
 parser.add_argument('--init', type=str, default='uniform', help='Initialization method: normal, uniform')
-parser.add_argument('--nn', type=str, default='egnn', help='Neural network type: egnn, egnn_noe, egnn_lj')
+parser.add_argument('--nn', type=str, default='egnn', help='Neural network type: egnn, egnn_noe, egnn_lj, mlp')
 parser.add_argument('--reflow', action='store_true', help='Use reflow data')
 parser.add_argument('--data_path', type=str, default='../lj.h5', help='Path to reflow data')
 parser.add_argument('--ckpt_dir', type=str, default=None)  # optional override


### PR DESCRIPTION
## Summary
- add script to sample 2D Gaussian mixtures with periodic boundaries and save as HDF5
- extend training script with an MLP network option and updated CLI

## Testing
- `python -m py_compile lj_reflow_template/generate_gaussian_mixture.py lj_reflow_template/train.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d049c77708333be73a0660594f731