### PR TITLE
Add script to visualize Gaussian mixture samples

### DIFF
--- a/lj_reflow_template/plot_gaussian_mixture.py
+++ b/lj_reflow_template/plot_gaussian_mixture.py
@@ -1,0 +1,43 @@
+import argparse
+import h5py
+import matplotlib.pyplot as plt
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Plot distribution of points from Gaussian mixture HDF5 file"
+    )
+    parser.add_argument("infile", type=str, help="Path to input HDF5 file")
+    parser.add_argument(
+        "--out",
+        type=str,
+        default="gaussian_mixture.png",
+        help="Output image filename",
+    )
+    parser.add_argument(
+        "--show",
+        action="store_true",
+        help="Display the plot instead of saving",
+    )
+    args = parser.parse_args()
+
+    with h5py.File(args.infile, "r") as f:
+        traj = f["trajectory"][:]
+
+    points = traj.reshape(-1, 2)
+
+    plt.figure()
+    plt.scatter(points[:, 0], points[:, 1], s=1, alpha=0.5)
+    plt.xlabel("x")
+    plt.ylabel("y")
+    plt.title("Gaussian mixture sample distribution")
+
+    if args.show:
+        plt.show()
+    else:
+        plt.savefig(args.out, dpi=300)
+        print(f"Saved plot to {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `plot_gaussian_mixture.py` to load Gaussian mixture HDF5 data and scatter-plot the combined points

## Testing
- `python lj_reflow_template/generate_gaussian_mixture.py /tmp/gmm.h5 --n_samples 100 --npoints 16 --boxlength 1.0 --n_peaks 4 --sigma 0.2`
- `python lj_reflow_template/plot_gaussian_mixture.py /tmp/gmm.h5 --out /tmp/gmm.png`
- `python -m py_compile lj_reflow_template/plot_gaussian_mixture.py`


------
https://chatgpt.com/codex/tasks/task_e_689d0f4c907c833381950461326377f2