### PR TITLE
Ensure transformer variant uses consistent data shape

### DIFF
--- a/lj_reflow_template/flashdiv/flows/transformer_variant.py
+++ b/lj_reflow_template/flashdiv/flows/transformer_variant.py
@@ -23,10 +23,11 @@ class PositionalEncoding(nn.Module):
 
 
 class TransformerVariant(FlowNet):
-    """Transformer tailored for inputs with shape ``[batch_size, dim]``.
+    """Transformer tailored for inputs shaped ``[batch_size, n_tokens, 1]``.
 
-    Each dimension is treated as a token. Positional encodings break the
-    permutational symmetry among dimensions.
+    Each scalar token is processed independently before attention mixes
+    information across tokens. Positional encodings break the permutational
+    symmetry among them.
     """
 
     def __init__(
@@ -71,8 +72,7 @@ class TransformerVariant(FlowNet):
         mask: torch.Tensor | None = None,
         return_attns: bool = False,
     ):
-        # reshape to (batch, seq_length, 1)
-        x = x.unsqueeze(-1)
+        # ``x`` is already shaped as (batch, seq_length, 1)
         x = self.affine_in(x)
         x = self.pos_encoding(x)
         x = self.dropout(x)
@@ -90,7 +90,7 @@ class TransformerVariant(FlowNet):
             if return_attns:
                 enc_slf_attn_list.append(enc_slf_attn)
 
-        x = self.affine_out(x).squeeze(-1)
+        x = self.affine_out(x)
         if return_attns:
             return x, enc_slf_attn_list
         return x

--- a/lj_reflow_template/generate_data.py
+++ b/lj_reflow_template/generate_data.py
@@ -9,6 +9,7 @@ from pytorch_lightning import seed_everything
 from flashdiv.flows.egnn_cutoff import EGNN_dynamicsPeriodic
 from flashdiv.flows.egnn_periodic import EGNN_dynamicsPeriodic as EGNN_dynamicsPeriodic_noe
 from flashdiv.flows.transformer import Transformer
+from flashdiv.flows.transformer_variant import TransformerVariant
 from flashdiv.flows.trainer import FlowTrainerTorus
 from flashdiv.flows.mlp import MLP
 from flashdiv.lj.lj import LJ
@@ -24,7 +25,12 @@ def args_to_str(args, ignore=("ckpt_dir", "ckpt_name", "nparticles", "dim", "kT"
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Generate reflow or final data")
-    parser.add_argument('--nn', type=str, default='egnn')
+    parser.add_argument(
+        '--nn',
+        type=str,
+        default='egnn',
+        help='Network type: egnn, egnn_noe, mlp, transformer, transformer_var'
+    )
     parser.add_argument('--ckpt_dir', type=str, required=True,
                         help='Path to model checkpoint')
     parser.add_argument('--nparticles', type=int, default=16)
@@ -104,6 +110,8 @@ def load_model(args):
         net = MLP(dim=input_dim, hidden_dim=hidden_nf, num_layers=nlayers).to(device)
     elif args.nn == 'transformer':
         net = Transformer(d_input=ljsystem.dim, d_output=ljsystem.dim)
+    elif args.nn == 'transformer_var':
+        net = TransformerVariant(seq_length=ljsystem.nparticles)
     trainer = FlowTrainerTorus.load_from_checkpoint(args.ckpt_dir, flow_model=net, strict=False)
 
     return trainer.flow_model.eval(), ljsystem

--- a/lj_reflow_template/generate_gaussian_mixture.py
+++ b/lj_reflow_template/generate_gaussian_mixture.py
@@ -20,12 +20,12 @@ def sample_mixture(
 
     Args:
         n_samples: Number of samples to draw.
-        dim: Dimensionality of each sample.
+        dim: Number of 1D points in each sample.
         n_peaks: Number of mixture components to sample.
         sigma: Standard deviation of each Gaussian component.
 
     Returns:
-        Tensor of shape ``(n_samples, dim)`` containing the generated samples.
+        Tensor of shape ``(n_samples, dim, 1)`` containing the generated samples.
     """
 
     # Enumerate all possible means located at ±0.25 in each dimension
@@ -44,7 +44,7 @@ def sample_mixture(
     peak_idx = torch.randint(0, n_peaks, (n_samples,))
     selected_means = means[peak_idx]
     samples = torch.randn(n_samples, dim) * sigma + selected_means
-    return samples
+    return samples.unsqueeze(-1)
 
 
 def main() -> None:

--- a/lj_reflow_template/train.py
+++ b/lj_reflow_template/train.py
@@ -8,6 +8,7 @@ from flashdiv.flows.egnn_cutoff import EGNN_dynamics, EGNN_dynamicsPeriodic
 from flashdiv.flows.egnn_periodic import EGNN_dynamicsPeriodic as EGNN_dynamicsPeriodic_noe
 from flashdiv.flows.mlp import MLP
 from flashdiv.flows.transformer import Transformer
+from flashdiv.flows.transformer_variant import TransformerVariant
 from flashdiv.flows.flow_net_torchdiffeq import FlowNet
 # from flashdiv.flows.message_passing import
 from flashdiv.flows.trainer import FlowTrainer, FlowTrainerTorus
@@ -181,7 +182,12 @@ parser.add_argument('--learning_rate', type=float, default=0.0005, help='Learnin
 parser.add_argument('--batch_size', type=int, default=256, help='Batch size')
 parser.add_argument('--nb_epochs', type=int, default=30, help='Number of epochs')
 parser.add_argument('--init', type=str, default='uniform', help='Initialization method: normal, uniform')
-parser.add_argument('--nn', type=str, default='egnn', help='Neural network type: egnn, egnn_noe, egnn_lj, mlp')
+parser.add_argument(
+    '--nn',
+    type=str,
+    default='egnn',
+    help='Neural network type: egnn, egnn_noe, egnn_lj, mlp, transformer, transformer_var'
+)
 parser.add_argument('--reflow', action='store_true', help='Use reflow data')
 parser.add_argument('--prefix', type=str, default='flow_model', help='Prefix for output files')
 parser.add_argument('--data_path', type=str, default='../lj.h5', help='Path to reflow data')


### PR DESCRIPTION
## Summary
- Keep `TransformerVariant` inputs and outputs shaped `(batch, n_points, 1)` and adjust forward pass accordingly
- Support `transformer_var` option in training and data-generation scripts
- Generate Gaussian mixture datasets with trailing singleton dimension for compatibility

## Testing
- `python -m py_compile lj_reflow_template/flashdiv/flows/transformer_variant.py lj_reflow_template/train.py lj_reflow_template/generate_data.py lj_reflow_template/generate_gaussian_mixture.py`


------
https://chatgpt.com/codex/tasks/task_e_68a50027d0008333805e25d7d0d246f6