### PR TITLE
Refactor ESS calculation for LJ flows

### DIFF
--- a/lj_reflow_template/flashdiv/flows/trainer.py
+++ b/lj_reflow_template/flashdiv/flows/trainer.py
@@ -5,11 +5,13 @@ from pytorch_lightning import LightningModule
 from einops import repeat, rearrange, reduce
 import torch.nn.functional as F
 import time
+from flashdiv.lj.utils import compute_normalized_ess
 
 class FlowTrainer(LightningModule):
     def __init__(self, flow_model, learning_rate=1e-3, permute=False, sigma = 0,
                  cfm_weight: float = 1.0, ml_weight: float = 0.0,
-                 div_method: str = 'full_jacobian', div_samples: int = 1):
+                 div_method: str = 'full_jacobian', div_samples: int = 1,
+                 target_distribution=None):
         super().__init__()
         self.flow_model = flow_model
         self.learning_rate = learning_rate
@@ -19,7 +21,8 @@ class FlowTrainer(LightningModule):
         self.ml_weight = ml_weight
         self.div_method = div_method
         self.div_samples = div_samples
-        self.save_hyperparameters()
+        self.target_distribution = target_distribution
+        self.save_hyperparameters(ignore=["target_distribution"])
 
     def permute_batch(self, batch):
 
@@ -70,9 +73,12 @@ class FlowTrainer(LightningModule):
                                               div_samples=self.div_samples, boxlength=None)
             ml_loss = -logp.mean()
             with torch.no_grad():
-                w = torch.exp(logp - logp.max())
-                w = w / w.sum()
-                ess = 1.0 / (w.pow(2).sum())
+                if self.target_distribution is not None:
+                    ess, _ = compute_normalized_ess(target, logp, self.target_distribution)
+                else:
+                    w = torch.exp(logp - logp.max())
+                    w = w / w.sum()
+                    ess = (1.0 / (w.pow(2).sum())) / w.shape[0]
                 ess_time = ess / (time.time() - start + 1e-8)
                 self.log('train_ess', ess, on_step=True, on_epoch=True)
                 self.log('train_ess_time', ess_time, on_step=True, on_epoch=True)
@@ -115,9 +121,12 @@ class FlowTrainer(LightningModule):
                                               div_samples=self.div_samples, boxlength=None)
             ml_loss = -logp.mean()
             with torch.no_grad():
-                w = torch.exp(logp - logp.max())
-                w = w / w.sum()
-                ess = 1.0 / (w.pow(2).sum())
+                if self.target_distribution is not None:
+                    ess, _ = compute_normalized_ess(target, logp, self.target_distribution)
+                else:
+                    w = torch.exp(logp - logp.max())
+                    w = w / w.sum()
+                    ess = (1.0 / (w.pow(2).sum())) / w.shape[0]
                 ess_time = ess / (time.time() - start + 1e-8)
                 self.log('val_ess', ess, on_step=False, on_epoch=True)
                 self.log('val_ess_time', ess_time, on_step=False, on_epoch=True)
@@ -137,7 +146,8 @@ class FlowTrainer(LightningModule):
 class FlowTrainerTorus(LightningModule):
     def __init__(self, flow_model, learning_rate=1e-3, permute=False, sigma = 0, boxlength=None,
                  cfm_weight: float = 1.0, ml_weight: float = 0.0,
-                 div_method: str = 'full_jacobian', div_samples: int = 1):
+                 div_method: str = 'full_jacobian', div_samples: int = 1,
+                 target_distribution=None):
         super().__init__()
         self.flow_model = flow_model
         self.learning_rate = learning_rate
@@ -148,7 +158,8 @@ class FlowTrainerTorus(LightningModule):
         self.ml_weight = ml_weight
         self.div_method = div_method
         self.div_samples = div_samples
-        self.save_hyperparameters()
+        self.target_distribution = target_distribution
+        self.save_hyperparameters(ignore=["target_distribution"])
 
     def permute_batch(self, batch):
 
@@ -212,9 +223,12 @@ class FlowTrainerTorus(LightningModule):
                                               div_samples=self.div_samples)
             ml_loss = -logp.mean()
             with torch.no_grad():
-                w = torch.exp(logp - logp.max())
-                w = w / w.sum()
-                ess = 1.0 / (w.pow(2).sum())
+                if self.target_distribution is not None:
+                    ess, _ = compute_normalized_ess(target, logp, self.target_distribution)
+                else:
+                    w = torch.exp(logp - logp.max())
+                    w = w / w.sum()
+                    ess = (1.0 / (w.pow(2).sum())) / w.shape[0]
                 ess_time = ess / (time.time() - start + 1e-8)
                 self.log('train_ess', ess, on_step=True, on_epoch=True)
                 self.log('train_ess_time', ess_time, on_step=True, on_epoch=True)
@@ -290,9 +304,12 @@ class FlowTrainerTorus(LightningModule):
                                               div_samples=self.div_samples)
             ml_loss = -logp.mean()
             with torch.no_grad():
-                w = torch.exp(logp - logp.max())
-                w = w / w.sum()
-                ess = 1.0 / (w.pow(2).sum())
+                if self.target_distribution is not None:
+                    ess, _ = compute_normalized_ess(target, logp, self.target_distribution)
+                else:
+                    w = torch.exp(logp - logp.max())
+                    w = w / w.sum()
+                    ess = (1.0 / (w.pow(2).sum())) / w.shape[0]
                 ess_time = ess / (time.time() - start + 1e-8)
                 self.log('val_ess', ess, on_step=False, on_epoch=True)
                 self.log('val_ess_time', ess_time, on_step=False, on_epoch=True)

--- a/lj_reflow_template/flashdiv/lj/utils.py
+++ b/lj_reflow_template/flashdiv/lj/utils.py
@@ -147,3 +147,33 @@ def com_logprob(x):
     dist = multivariate_normal(cov=singular_cov , allow_singular=True)
 
     return dist.logpdf(x.view(-1, nbparticles * dim))
+
+
+def compute_normalized_ess(samples, log_q, ljsystem):
+    """Compute normalized effective sample size (ESS).
+
+    Parameters
+    ----------
+    samples : torch.Tensor
+        Samples drawn from the generative model with shape ``[batch, N, D]``.
+    log_q : torch.Tensor
+        Log probabilities of the samples under the generative model with
+        shape ``[batch]``.
+    ljsystem : object
+        Target distribution providing ``potential`` and ``kT`` attributes.
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        ``ess_norm`` – ESS normalized by the number of samples (0–1) and the
+        corresponding normalized importance weights.
+    """
+    with torch.no_grad():
+        log_target = -ljsystem.potential(samples) / ljsystem.kT
+        log_w = log_target - log_q
+        w = torch.exp(log_w - log_w.max())
+        w = w / w.sum()
+        ess = 1.0 / (w.pow(2).sum())
+        ess_norm = ess / w.shape[0]
+    return ess_norm, w
+

--- a/lj_reflow_template/generate_data.py
+++ b/lj_reflow_template/generate_data.py
@@ -112,7 +112,9 @@ def load_model(args):
         net = Transformer(d_input=ljsystem.dim, d_output=ljsystem.dim)
     elif args.nn == 'transformer_var':
         net = TransformerVariant(seq_length=ljsystem.nparticles)
-    trainer = FlowTrainerTorus.load_from_checkpoint(args.ckpt_dir, flow_model=net, strict=False)
+    trainer = FlowTrainerTorus.load_from_checkpoint(
+        args.ckpt_dir, flow_model=net, strict=False, target_distribution=ljsystem
+    )
 
     return trainer.flow_model.eval(), ljsystem
 

--- a/lj_reflow_template/train.py
+++ b/lj_reflow_template/train.py
@@ -144,6 +144,7 @@ def train_model():
         ml_weight=args.ml_weight,
         div_method=args.div_method,
         div_samples=args.div_samples,
+        target_distribution=ljsystem,
     )
 
     ckpt_cb = ModelCheckpoint(


### PR DESCRIPTION
## Summary
- add utility to compute normalized ESS from LJ potential and model log probs
- integrate ESS computation into training and validation for both FlowTrainer and FlowTrainerTorus
- pass target distribution through training and sample generation scripts

## Testing
- `pytest`
- `python -m py_compile lj_reflow_template/flashdiv/lj/utils.py lj_reflow_template/flashdiv/flows/trainer.py lj_reflow_template/generate_data.py lj_reflow_template/train.py`


------
https://chatgpt.com/codex/tasks/task_e_68ace62eac3c83338d86033a5636333b