### PR TITLE
Add optional ESS variance loss

### DIFF
--- a/lj_reflow_template/flashdiv/flows/trainer.py
+++ b/lj_reflow_template/flashdiv/flows/trainer.py
@@ -5,13 +5,12 @@ from pytorch_lightning import LightningModule
 from einops import repeat, rearrange, reduce
 import torch.nn.functional as F
 import time
-from flashdiv.lj.utils import compute_normalized_ess
 
 class FlowTrainer(LightningModule):
     def __init__(self, flow_model, learning_rate=1e-3, permute=False, sigma = 0,
                  cfm_weight: float = 1.0, ml_weight: float = 0.0,
                  div_method: str = 'full_jacobian', div_samples: int = 1,
-                 target_distribution=None):
+                 target_distribution=None, ess_var_weight: float = 0.0):
         super().__init__()
         self.flow_model = flow_model
         self.learning_rate = learning_rate
@@ -22,6 +21,7 @@ class FlowTrainer(LightningModule):
         self.div_method = div_method
         self.div_samples = div_samples
         self.target_distribution = target_distribution
+        self.ess_var_weight = ess_var_weight
         self.save_hyperparameters(ignore=["target_distribution"])
 
     def permute_batch(self, batch):
@@ -67,24 +67,39 @@ class FlowTrainer(LightningModule):
         cfm_loss = nn.MSELoss()(v, vt)
 
         ml_loss = torch.tensor(0.0, device=base.device)
-        if self.ml_weight > 0:
+        ess_var_loss = torch.tensor(0.0, device=base.device)
+        if self.ml_weight > 0 or self.ess_var_weight > 0:
             start = time.time()
             _, logp = self.flow_model.log_prob(target, div_method=self.div_method,
                                               div_samples=self.div_samples, boxlength=None)
-            ml_loss = -logp.mean()
-            with torch.no_grad():
-                if self.target_distribution is not None:
-                    ess, _ = compute_normalized_ess(target, logp, self.target_distribution)
-                else:
-                    w = torch.exp(logp - logp.max())
-                    w = w / w.sum()
-                    ess = (1.0 / (w.pow(2).sum())) / w.shape[0]
-                ess_time = ess / (time.time() - start + 1e-8)
-                self.log('train_ess', ess, on_step=True, on_epoch=True)
-                self.log('train_ess_time', ess_time, on_step=True, on_epoch=True)
+            if self.ml_weight > 0:
+                ml_loss = -logp.mean()
+
+            if self.target_distribution is not None:
+                with torch.no_grad():
+                    log_target = -self.target_distribution.potential(target) / self.target_distribution.kT
+                log_w = log_target - logp
+            else:
+                log_w = logp
+
+            log_w = log_w - log_w.max()
+            w = torch.exp(log_w)
+            w = w / w.sum()
+            ess = 1.0 / (w.pow(2).sum())
+            ess_norm = ess / w.shape[0]
+            ess_var_loss = w.var(unbiased=False)
+            ess_time = ess_norm / (time.time() - start + 1e-8)
+            self.log('train_ess', ess_norm, on_step=True, on_epoch=True)
+            self.log('train_ess_time', ess_time, on_step=True, on_epoch=True)
+            if self.ess_var_weight > 0:
+                self.log('train_ess_var', ess_var_loss, on_step=True, on_epoch=True)
 
         v_squared_norm = (v**2).mean()
-        total_loss = self.cfm_weight * cfm_loss + self.ml_weight * ml_loss
+        total_loss = (
+            self.cfm_weight * cfm_loss
+            + self.ml_weight * ml_loss
+            + self.ess_var_weight * ess_var_loss
+        )
         self.log("train_loss", total_loss / v_squared_norm, on_step=True, on_epoch=True)
         if self.ml_weight > 0:
             self.log('train_ml', ml_loss, on_step=True, on_epoch=True)
@@ -115,24 +130,37 @@ class FlowTrainer(LightningModule):
         cfm_loss = nn.MSELoss()(v, vt)
 
         ml_loss = torch.tensor(0.0, device=base.device)
-        if self.ml_weight > 0:
+        ess_var_loss = torch.tensor(0.0, device=base.device)
+        if self.ml_weight > 0 or self.ess_var_weight > 0:
             start = time.time()
             _, logp = self.flow_model.log_prob(target, div_method=self.div_method,
                                               div_samples=self.div_samples, boxlength=None)
-            ml_loss = -logp.mean()
+            if self.ml_weight > 0:
+                ml_loss = -logp.mean()
             with torch.no_grad():
                 if self.target_distribution is not None:
-                    ess, _ = compute_normalized_ess(target, logp, self.target_distribution)
+                    log_target = -self.target_distribution.potential(target) / self.target_distribution.kT
+                    log_w = log_target - logp
                 else:
-                    w = torch.exp(logp - logp.max())
-                    w = w / w.sum()
-                    ess = (1.0 / (w.pow(2).sum())) / w.shape[0]
-                ess_time = ess / (time.time() - start + 1e-8)
-                self.log('val_ess', ess, on_step=False, on_epoch=True)
-                self.log('val_ess_time', ess_time, on_step=False, on_epoch=True)
+                    log_w = logp
+                log_w = log_w - log_w.max()
+                w = torch.exp(log_w)
+                w = w / w.sum()
+                ess = 1.0 / (w.pow(2).sum())
+                ess_norm = ess / w.shape[0]
+                ess_var_loss = w.var(unbiased=False)
+                ess_time = ess_norm / (time.time() - start + 1e-8)
+            self.log('val_ess', ess_norm, on_step=False, on_epoch=True)
+            self.log('val_ess_time', ess_time, on_step=False, on_epoch=True)
+            if self.ess_var_weight > 0:
+                self.log('val_ess_var', ess_var_loss, on_step=False, on_epoch=True)
 
         v_squared_norm = (v**2).mean()
-        total_loss = self.cfm_weight * cfm_loss + self.ml_weight * ml_loss
+        total_loss = (
+            self.cfm_weight * cfm_loss
+            + self.ml_weight * ml_loss
+            + self.ess_var_weight * ess_var_loss
+        )
         self.log("val_loss", total_loss / v_squared_norm, on_step=False, on_epoch=True)
         if self.ml_weight > 0:
             self.log('val_ml', ml_loss, on_step=False, on_epoch=True)
@@ -147,7 +175,7 @@ class FlowTrainerTorus(LightningModule):
     def __init__(self, flow_model, learning_rate=1e-3, permute=False, sigma = 0, boxlength=None,
                  cfm_weight: float = 1.0, ml_weight: float = 0.0,
                  div_method: str = 'full_jacobian', div_samples: int = 1,
-                 target_distribution=None):
+                 target_distribution=None, ess_var_weight: float = 0.0):
         super().__init__()
         self.flow_model = flow_model
         self.learning_rate = learning_rate
@@ -159,6 +187,7 @@ class FlowTrainerTorus(LightningModule):
         self.div_method = div_method
         self.div_samples = div_samples
         self.target_distribution = target_distribution
+        self.ess_var_weight = ess_var_weight
         self.save_hyperparameters(ignore=["target_distribution"])
 
     def permute_batch(self, batch):
@@ -216,25 +245,38 @@ class FlowTrainerTorus(LightningModule):
         cfm_loss = (weight * per_sample_loss).sum() / weight.sum()
 
         ml_loss = torch.tensor(0.0, device=base.device)
-        if self.ml_weight > 0:
+        ess_var_loss = torch.tensor(0.0, device=base.device)
+        if self.ml_weight > 0 or self.ess_var_weight > 0:
             start = time.time()
             _, logp = self.flow_model.log_prob(target, boxlength=self.boxlength,
                                               div_method=self.div_method,
                                               div_samples=self.div_samples)
-            ml_loss = -logp.mean()
-            with torch.no_grad():
-                if self.target_distribution is not None:
-                    ess, _ = compute_normalized_ess(target, logp, self.target_distribution)
-                else:
-                    w = torch.exp(logp - logp.max())
-                    w = w / w.sum()
-                    ess = (1.0 / (w.pow(2).sum())) / w.shape[0]
-                ess_time = ess / (time.time() - start + 1e-8)
-                self.log('train_ess', ess, on_step=True, on_epoch=True)
-                self.log('train_ess_time', ess_time, on_step=True, on_epoch=True)
+            if self.ml_weight > 0:
+                ml_loss = -logp.mean()
+            if self.target_distribution is not None:
+                with torch.no_grad():
+                    log_target = -self.target_distribution.potential(target) / self.target_distribution.kT
+                log_w = log_target - logp
+            else:
+                log_w = logp
+            log_w = log_w - log_w.max()
+            w = torch.exp(log_w)
+            w = w / w.sum()
+            ess = 1.0 / (w.pow(2).sum())
+            ess_norm = ess / w.shape[0]
+            ess_var_loss = w.var(unbiased=False)
+            ess_time = ess_norm / (time.time() - start + 1e-8)
+            self.log('train_ess', ess_norm, on_step=True, on_epoch=True)
+            self.log('train_ess_time', ess_time, on_step=True, on_epoch=True)
+            if self.ess_var_weight > 0:
+                self.log('train_ess_var', ess_var_loss, on_step=True, on_epoch=True)
 
         v_squared_norm = (vtorus ** 2).mean()
-        total_loss = self.cfm_weight * cfm_loss + self.ml_weight * ml_loss
+        total_loss = (
+            self.cfm_weight * cfm_loss
+            + self.ml_weight * ml_loss
+            + self.ess_var_weight * ess_var_loss
+        )
         self.log("train_loss", total_loss / v_squared_norm, on_step=True, on_epoch=True)
         if self.ml_weight > 0:
             self.log('train_ml', ml_loss, on_step=True, on_epoch=True)
@@ -297,25 +339,38 @@ class FlowTrainerTorus(LightningModule):
         cfm_loss = (weight * per_sample_loss).sum()/ weight.sum()
 
         ml_loss = torch.tensor(0.0, device=base.device)
-        if self.ml_weight > 0:
+        ess_var_loss = torch.tensor(0.0, device=base.device)
+        if self.ml_weight > 0 or self.ess_var_weight > 0:
             start = time.time()
             _, logp = self.flow_model.log_prob(target, boxlength=self.boxlength,
                                               div_method=self.div_method,
                                               div_samples=self.div_samples)
-            ml_loss = -logp.mean()
+            if self.ml_weight > 0:
+                ml_loss = -logp.mean()
             with torch.no_grad():
                 if self.target_distribution is not None:
-                    ess, _ = compute_normalized_ess(target, logp, self.target_distribution)
+                    log_target = -self.target_distribution.potential(target) / self.target_distribution.kT
+                    log_w = log_target - logp
                 else:
-                    w = torch.exp(logp - logp.max())
-                    w = w / w.sum()
-                    ess = (1.0 / (w.pow(2).sum())) / w.shape[0]
-                ess_time = ess / (time.time() - start + 1e-8)
-                self.log('val_ess', ess, on_step=False, on_epoch=True)
-                self.log('val_ess_time', ess_time, on_step=False, on_epoch=True)
+                    log_w = logp
+                log_w = log_w - log_w.max()
+                w = torch.exp(log_w)
+                w = w / w.sum()
+                ess = 1.0 / (w.pow(2).sum())
+                ess_norm = ess / w.shape[0]
+                ess_var_loss = w.var(unbiased=False)
+                ess_time = ess_norm / (time.time() - start + 1e-8)
+            self.log('val_ess', ess_norm, on_step=False, on_epoch=True)
+            self.log('val_ess_time', ess_time, on_step=False, on_epoch=True)
+            if self.ess_var_weight > 0:
+                self.log('val_ess_var', ess_var_loss, on_step=False, on_epoch=True)
 
         v_squared_norm = (vtorus ** 2).mean()
-        total_loss = self.cfm_weight * cfm_loss + self.ml_weight * ml_loss
+        total_loss = (
+            self.cfm_weight * cfm_loss
+            + self.ml_weight * ml_loss
+            + self.ess_var_weight * ess_var_loss
+        )
         self.log("val_loss", total_loss / v_squared_norm, on_step=False, on_epoch=True)
         if self.ml_weight > 0:
             self.log('val_ml', ml_loss, on_step=False, on_epoch=True)

--- a/lj_reflow_template/train.py
+++ b/lj_reflow_template/train.py
@@ -145,6 +145,7 @@ def train_model():
         div_method=args.div_method,
         div_samples=args.div_samples,
         target_distribution=ljsystem,
+        ess_var_weight=args.ess_var_weight,
     )
 
     ckpt_cb = ModelCheckpoint(
@@ -179,6 +180,7 @@ def train_model():
             div_method=args.div_method,
             div_samples=args.div_samples,
             target_distribution=ljsystem,
+            ess_var_weight=args.ess_var_weight,
         )
 
     trainer.fit(velocitytrainer, train_loader, val_loader)
@@ -230,6 +232,8 @@ parser.add_argument('--div_method', type=str, default='direct_trace',
                     help='Divergence computation method for log-likelihood')
 parser.add_argument('--div_samples', type=int, default=1,
                     help='Samples for Hutchinson trace estimator if used')
+parser.add_argument('--ess_var_weight', type=float, default=0.0,
+                    help='Weight for variance of ESS loss term')
 
 
 args = parser.parse_args()


### PR DESCRIPTION
## Summary
- add `ess_var_weight` to flow trainers to optionally penalize variance in normalized importance weights
- wire optional ESS variance loss into training and validation
- expose `--ess_var_weight` CLI flag in training script

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile lj_reflow_template/flashdiv/flows/trainer.py lj_reflow_template/train.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad1c1b568c83339dec37895346760c