### PR TITLE
Enable differentiable sampling and ESS from model samples

### DIFF
--- a/lj_reflow_template/flashdiv/flows/flow_net_torchdiffeq.py
+++ b/lj_reflow_template/flashdiv/flows/flow_net_torchdiffeq.py
@@ -121,18 +121,31 @@ class FlowNet(nn.Module):
 
 
   
-    # @torch.no_grad()
-    def sample_logprob(self, x, logprob=None, times=None, reverse=False, verbose=False, **kwargs):
-        """
-        ODE integration returning the trajectory and logprob.
+    def sample_logprob(self, x, logprob=None, times=None, reverse=False,
+                       verbose=False, differentiable: bool = False, **kwargs):
+        """Integrate the flow and track log-probability.
 
-        Args:
-            x: initial position (x0 if forward, x1 if reverse)
-            logprob: initial log probability (if reverse=False)
-            times: time vector (optional)
-            reverse: if True, integrate from t=1 to t=0
-            verbose: print diagnostic info
-            kwargs: passed to odeint and divergence
+        Parameters
+        ----------
+        x : torch.Tensor
+            Initial state.  ``x0`` if ``reverse=False`` else ``x1``.
+        logprob : torch.Tensor, optional
+            Initial log-density. Must be provided when ``reverse=False``.
+        times : torch.Tensor, optional
+            Explicit time grid for integration.
+        reverse : bool, optional
+            If ``True`` integrate from ``t=1`` to ``t=0``.
+        verbose : bool, optional
+            Print diagnostic information.
+        differentiable : bool, optional
+            When ``True`` no ``detach`` or ``torch.no_grad`` is used so
+            gradients w.r.t. the model parameters can flow through the
+            integration.  The default ``False`` reproduces the previous
+            behaviour and performs the integration without tracking
+            gradients.
+        **kwargs : dict
+            Additional arguments forwarded to ``torchdiffeq.odeint`` and the
+            divergence computation.
         """
         batch_size = x.shape[0]
         npart = x.shape[-2]
@@ -193,6 +206,8 @@ class FlowNet(nn.Module):
             ),
             dim=0
         )
+        if not differentiable:
+            state0 = state0.detach()
 
         class IntegrationFunc:
             def __init__(self, model):
@@ -201,13 +216,16 @@ class FlowNet(nn.Module):
             def __call__(self, t, state):
                 xs = state[:batch_size]
                 t_ = torch.full((batch_size,), t.item(), device=xs.device)
-                div = self.model._divergence(xs, t_, **div_kwargs).detach()
-                v = self.model.forward(xs, t_).detach()
+                div = self.model._divergence(xs, t_, **div_kwargs)
+                v = self.model.forward(xs, t_)
+                if not differentiable:
+                    div = div.detach()
+                    v = v.detach()
                 # flip sign for reverse integration
                 vel = -v if reverse else v
                 dlogp = div if reverse else -div
 
-                return torch.cat(
+                out = torch.cat(
                     (
                         vel,
                         repeat(
@@ -217,7 +235,8 @@ class FlowNet(nn.Module):
                         )
                     ),
                     dim=0
-                ).detach()
+                )
+                return out.detach() if not differentiable else out
 
         integration_func = IntegrationFunc(self)
 
@@ -227,7 +246,11 @@ class FlowNet(nn.Module):
                 xs[:batch_size]  = (xs[:batch_size] + 0.5 * boxlength) % boxlength - 0.5 * boxlength
             setattr(integration_func, 'callback_step', lambda t, xs, dt: mod(xs))
 
-        integrated_state = odeint(integration_func, state0, times, **kwargs)
+        if differentiable:
+            integrated_state = odeint(integration_func, state0, times, **kwargs)
+        else:
+            with torch.no_grad():
+                integrated_state = odeint(integration_func, state0, times, **kwargs)
         all_xs = integrated_state[:, :batch_size]
         all_logprobs = integrated_state[:, batch_size:, 0, 0]
 

--- a/lj_reflow_template/flashdiv/flows/trainer.py
+++ b/lj_reflow_template/flashdiv/flows/trainer.py
@@ -68,20 +68,35 @@ class FlowTrainer(LightningModule):
 
         ml_loss = torch.tensor(0.0, device=base.device)
         weight_var = torch.tensor(0.0, device=base.device)
-        if self.ml_weight > 0 or self.weight_var_weight > 0:
-            start = time.time()
+        if self.ml_weight > 0:
             _, logp = self.flow_model.log_prob(target, div_method=self.div_method,
                                               div_samples=self.div_samples, boxlength=None)
-            if self.ml_weight > 0:
-                ml_loss = -logp.mean()
+            ml_loss = -logp.mean()
 
-            if self.target_distribution is not None:
-                with torch.no_grad():
-                    log_target = -self.target_distribution.potential(target) / self.target_distribution.kT
-                log_w = log_target - logp
+        if self.target_distribution is not None or self.weight_var_weight > 0:
+            start = time.time()
+            logprob0 = torch.zeros(base.shape[0], device=base.device)
+            if self.weight_var_weight > 0:
+                xs_traj, logq_traj = self.flow_model.sample_logprob(
+                    base, logprob0, div_method=self.div_method,
+                    div_samples=self.div_samples, boxlength=None,
+                    differentiable=True,
+                )
             else:
-                log_w = logp
-
+                with torch.no_grad():
+                    xs_traj, logq_traj = self.flow_model.sample_logprob(
+                        base, logprob0, div_method=self.div_method,
+                        div_samples=self.div_samples, boxlength=None,
+                        differentiable=False,
+                    )
+            xs = xs_traj[-1]
+            log_q = logq_traj[-1]
+            with torch.no_grad():
+                if self.target_distribution is not None:
+                    log_target = -self.target_distribution.potential(xs) / self.target_distribution.kT
+                else:
+                    log_target = torch.zeros_like(log_q)
+            log_w = log_target - log_q
             log_w = log_w - log_w.max()
             w = torch.exp(log_w)
             w = w / w.sum()
@@ -131,18 +146,27 @@ class FlowTrainer(LightningModule):
 
         ml_loss = torch.tensor(0.0, device=base.device)
         weight_var = torch.tensor(0.0, device=base.device)
-        if self.ml_weight > 0 or self.weight_var_weight > 0:
-            start = time.time()
+        if self.ml_weight > 0:
             _, logp = self.flow_model.log_prob(target, div_method=self.div_method,
                                               div_samples=self.div_samples, boxlength=None)
-            if self.ml_weight > 0:
-                ml_loss = -logp.mean()
+            ml_loss = -logp.mean()
+
+        if self.target_distribution is not None or self.weight_var_weight > 0:
+            start = time.time()
+            logprob0 = torch.zeros(base.shape[0], device=base.device)
             with torch.no_grad():
+                xs_traj, logq_traj = self.flow_model.sample_logprob(
+                    base, logprob0, div_method=self.div_method,
+                    div_samples=self.div_samples, boxlength=None,
+                    differentiable=False,
+                )
+                xs = xs_traj[-1]
+                log_q = logq_traj[-1]
                 if self.target_distribution is not None:
-                    log_target = -self.target_distribution.potential(target) / self.target_distribution.kT
-                    log_w = log_target - logp
+                    log_target = -self.target_distribution.potential(xs) / self.target_distribution.kT
                 else:
-                    log_w = logp
+                    log_target = torch.zeros_like(log_q)
+                log_w = log_target - log_q
                 log_w = log_w - log_w.max()
                 w = torch.exp(log_w)
                 w = w / w.sum()
@@ -246,19 +270,36 @@ class FlowTrainerTorus(LightningModule):
 
         ml_loss = torch.tensor(0.0, device=base.device)
         weight_var = torch.tensor(0.0, device=base.device)
-        if self.ml_weight > 0 or self.weight_var_weight > 0:
-            start = time.time()
+        if self.ml_weight > 0:
             _, logp = self.flow_model.log_prob(target, boxlength=self.boxlength,
                                               div_method=self.div_method,
                                               div_samples=self.div_samples)
-            if self.ml_weight > 0:
-                ml_loss = -logp.mean()
-            if self.target_distribution is not None:
-                with torch.no_grad():
-                    log_target = -self.target_distribution.potential(target) / self.target_distribution.kT
-                log_w = log_target - logp
+            ml_loss = -logp.mean()
+
+        if self.target_distribution is not None or self.weight_var_weight > 0:
+            start = time.time()
+            logprob0 = torch.zeros(base.shape[0], device=base.device)
+            if self.weight_var_weight > 0:
+                xs_traj, logq_traj = self.flow_model.sample_logprob(
+                    base, logprob0, boxlength=self.boxlength,
+                    div_method=self.div_method, div_samples=self.div_samples,
+                    differentiable=True,
+                )
             else:
-                log_w = logp
+                with torch.no_grad():
+                    xs_traj, logq_traj = self.flow_model.sample_logprob(
+                        base, logprob0, boxlength=self.boxlength,
+                        div_method=self.div_method, div_samples=self.div_samples,
+                        differentiable=False,
+                    )
+            xs = xs_traj[-1]
+            log_q = logq_traj[-1]
+            with torch.no_grad():
+                if self.target_distribution is not None:
+                    log_target = -self.target_distribution.potential(xs) / self.target_distribution.kT
+                else:
+                    log_target = torch.zeros_like(log_q)
+            log_w = log_target - log_q
             log_w = log_w - log_w.max()
             w = torch.exp(log_w)
             w = w / w.sum()
@@ -340,19 +381,28 @@ class FlowTrainerTorus(LightningModule):
 
         ml_loss = torch.tensor(0.0, device=base.device)
         weight_var = torch.tensor(0.0, device=base.device)
-        if self.ml_weight > 0 or self.weight_var_weight > 0:
-            start = time.time()
+        if self.ml_weight > 0:
             _, logp = self.flow_model.log_prob(target, boxlength=self.boxlength,
                                               div_method=self.div_method,
                                               div_samples=self.div_samples)
-            if self.ml_weight > 0:
-                ml_loss = -logp.mean()
+            ml_loss = -logp.mean()
+
+        if self.target_distribution is not None or self.weight_var_weight > 0:
+            start = time.time()
+            logprob0 = torch.zeros(base.shape[0], device=base.device)
             with torch.no_grad():
+                xs_traj, logq_traj = self.flow_model.sample_logprob(
+                    base, logprob0, boxlength=self.boxlength,
+                    div_method=self.div_method, div_samples=self.div_samples,
+                    differentiable=False,
+                )
+                xs = xs_traj[-1]
+                log_q = logq_traj[-1]
                 if self.target_distribution is not None:
-                    log_target = -self.target_distribution.potential(target) / self.target_distribution.kT
-                    log_w = log_target - logp
+                    log_target = -self.target_distribution.potential(xs) / self.target_distribution.kT
                 else:
-                    log_w = logp
+                    log_target = torch.zeros_like(log_q)
+                log_w = log_target - log_q
                 log_w = log_w - log_w.max()
                 w = torch.exp(log_w)
                 w = w / w.sum()


### PR DESCRIPTION
## Summary
- Add `differentiable` option to `FlowNet.sample_logprob` to allow gradients through ODE sampling
- Compute importance weights, variance, and ESS from model-generated samples during training and validation
- Support the above for both regular and torus trainers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad2ca73db883338d8b294dbd6490fe