### PR TITLE
Use adjoint ODE solver for differentiable sampling

### DIFF
--- a/lj_reflow_template/flashdiv/flows/flow_net_torchdiffeq.py
+++ b/lj_reflow_template/flashdiv/flows/flow_net_torchdiffeq.py
@@ -251,7 +251,7 @@ class FlowNet(nn.Module):
             setattr(integration_func, 'callback_step', lambda t, xs, dt: mod(xs))
 
         if differentiable:
-            integrated_state = odeint(integration_func, state0, times, **odeint_kwargs)
+            integrated_state = odeint_adjoint(integration_func, state0, times, **odeint_kwargs)
         else:
             with torch.no_grad():
                 integrated_state = odeint(integration_func, state0, times, **odeint_kwargs)


### PR DESCRIPTION
## Summary
- Switch differentiable sampling to use torchdiffeq's `odeint_adjoint` to reduce memory usage

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad3c0de69483338c3983f22f5b3a45