### PR TITLE
Make IntegrationFunc an nn.Module

### DIFF
--- a/lj_reflow_template/flashdiv/flows/flow_net_torchdiffeq.py
+++ b/lj_reflow_template/flashdiv/flows/flow_net_torchdiffeq.py
@@ -213,11 +213,12 @@ class FlowNet(nn.Module):
         if not differentiable:
             state0 = state0.detach()
 
-        class IntegrationFunc:
+        class IntegrationFunc(nn.Module):
             def __init__(self, model):
+                super().__init__()
                 self.model = model
 
-            def __call__(self, t, state):
+            def forward(self, t, state):
                 xs = state[:batch_size]
                 t_ = torch.full((batch_size,), t.item(), device=xs.device)
                 div = self.model._divergence(xs, t_, **div_kwargs)
@@ -225,7 +226,6 @@ class FlowNet(nn.Module):
                 if not differentiable:
                     div = div.detach()
                     v = v.detach()
-                # flip sign for reverse integration
                 vel = -v if reverse else v
                 dlogp = div if reverse else -div
 


### PR DESCRIPTION
## Summary
- convert `sample_logprob`'s IntegrationFunc to `nn.Module` with a `forward` method so `odeint_adjoint` tracks model parameters

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68ad3da552648333a0bc91ee92c213ed