### PR TITLE
Handle unused gradients in PathGrad

### DIFF
--- a/lj_reflow_template/flashdiv/flows/trainer.py
+++ b/lj_reflow_template/flashdiv/flows/trainer.py
@@ -23,7 +23,15 @@ class PathGrad(torch.autograd.Function):
     @staticmethod
     def backward(ctx, g):
         l, x = ctx.saved_tensors
-        grad_x = torch.autograd.grad(l, x, g, retain_graph=True)[0]
+        grad_x = torch.autograd.grad(
+            l,
+            x,
+            g,
+            retain_graph=True,
+            allow_unused=True,
+        )[0]
+        if grad_x is None:
+            grad_x = torch.zeros_like(x)
         return None, grad_x
 
 class FlowTrainer(LightningModule):


### PR DESCRIPTION
## Summary
- Allow PathGrad to handle cases where gradients are unused by enabling `allow_unused` in `torch.autograd.grad`
- Substitute `torch.zeros_like(x)` when the gradient is `None`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad6699bb1c8333b65da36cbdca0175